### PR TITLE
Fix typo in error handling case

### DIFF
--- a/tasks/terser.js
+++ b/tasks/terser.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
         var result = Terser.minify(src, options);
 
         if (result.error) {
-          grunt.logs.error(result.error);
+          grunt.log.error(result.error);
           return false;
         }
 


### PR DESCRIPTION
Currently, grunt throws an exception without showing the error message. This fixes it.