### PR TITLE
Move terser to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
-    "terser": "^4.6.3"
+  "peerDependencies": {
+    "terser": "5.x"
   },
   "devDependencies": {
     "grunt": "^1.0.4",


### PR DESCRIPTION
Move terser to peerDependencies so users can use whatever version of Terser they want.