### PR TITLE
Prevent minify without resolved files

### DIFF
--- a/tasks/terser.js
+++ b/tasks/terser.js
@@ -52,6 +52,10 @@ module.exports = (
               {},
             );
 
+          if(!Object.keys(src).length) {
+            grunt.log.warn(`No source files were found.`);
+            return false;
+          }
           // Minify file code.
           const result = await minify(src, options);
 


### PR DESCRIPTION
Found this with the `files` config

```js
{
    src: 'filePathTypo.js',
    dest: 'filePathTypo.js',
},
```
which throws an terser exception (reported in https://github.com/terser/terser/issues/1449)